### PR TITLE
Use .js file extensions for ESM

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,4 +3,5 @@ module.exports = {
   transform: {
     "\\.ts$": "esbuild-jest",
   },
+  resolver: "jest-ts-webcompat-resolver",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,21 @@
       "name": "@foxglove/template",
       "version": "0.0.1",
       "devDependencies": {
-        "@foxglove/eslint-plugin": "0.11.1",
+        "@foxglove/eslint-plugin": "0.12.0",
         "@foxglove/tsconfig": "1.0.0",
         "@types/jest": "26.0.23",
-        "@typescript-eslint/eslint-plugin": "4.28.0",
-        "@typescript-eslint/parser": "4.28.0",
+        "@typescript-eslint/eslint-plugin": "4.28.1",
+        "@typescript-eslint/parser": "4.28.1",
         "esbuild-jest": "0.5.0",
         "eslint": "7.29.0",
         "eslint-config-prettier": "8.3.0",
         "eslint-plugin-import": "2.23.4",
         "eslint-plugin-jest": "24.3.6",
         "eslint-plugin-prettier": "3.4.0",
-        "jest": "27.0.5",
+        "jest": "27.0.6",
+        "jest-ts-webcompat-resolver": "^1.0.0",
         "prettier": "2.3.2",
-        "typescript": "4.3.4"
+        "typescript": "4.3.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -740,9 +741,9 @@
       }
     },
     "node_modules/@foxglove/eslint-plugin": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@foxglove/eslint-plugin/-/eslint-plugin-0.11.1.tgz",
-      "integrity": "sha512-c3rGYgitP9ATCzz7xtOgcy+a/UkKFTURKf4zykx3P3Z91eeHPaXFRaTWeRJbxlNj+zlWVA7U5QJNW4h3yj5UzQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@foxglove/eslint-plugin/-/eslint-plugin-0.12.0.tgz",
+      "integrity": "sha512-pBVoH0eZHYCURTbSYLO0DKxBo/zBn5P/t3HurU6njgt8caQ2SIPCWYleXwA2Cbr4+RepUB6+l53JR3m9bfa/Fg==",
       "dev": true,
       "peerDependencies": {
         "eslint": "^7",
@@ -863,16 +864,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.2.tgz",
-      "integrity": "sha512-/zYigssuHLImGeMAACkjI4VLAiiJznHgAl3xnFT19iWyct2LhrH3KXOjHRmxBGTkiPLZKKAJAgaPpiU9EZ9K+w==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.6.tgz",
+      "integrity": "sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.0.2",
-        "jest-util": "^27.0.2",
+        "jest-message-util": "^27.0.6",
+        "jest-util": "^27.0.6",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -880,35 +881,35 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.5.tgz",
-      "integrity": "sha512-g73//jF0VwsOIrWUC9Cqg03lU3QoAMFxVjsm6n6yNmwZcQPN/o8w+gLWODw5VfKNFZT38otXHWxc6b8eGDUpEA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.6.tgz",
+      "integrity": "sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.0.2",
-        "@jest/reporters": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/reporters": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.0.2",
-        "jest-config": "^27.0.5",
-        "jest-haste-map": "^27.0.5",
-        "jest-message-util": "^27.0.2",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-resolve-dependencies": "^27.0.5",
-        "jest-runner": "^27.0.5",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
-        "jest-watcher": "^27.0.2",
+        "jest-changed-files": "^27.0.6",
+        "jest-config": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-resolve-dependencies": "^27.0.6",
+        "jest-runner": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
+        "jest-watcher": "^27.0.6",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -928,62 +929,62 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.5.tgz",
-      "integrity": "sha512-IAkJPOT7bqn0GiX5LPio6/e1YpcmLbrd8O5EFYpAOZ6V+9xJDsXjdgN2vgv9WOKIs/uA1kf5WeD96HhlBYO+FA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.6.tgz",
+      "integrity": "sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
-        "jest-mock": "^27.0.3"
+        "jest-mock": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.5.tgz",
-      "integrity": "sha512-d6Tyf7iDoKqeUdwUKrOBV/GvEZRF67m7lpuWI0+SCD9D3aaejiOQZxAOxwH2EH/W18gnfYaBPLi0VeTGBHtQBg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
+      "integrity": "sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@sinonjs/fake-timers": "^7.0.2",
         "@types/node": "*",
-        "jest-message-util": "^27.0.2",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2"
+        "jest-message-util": "^27.0.6",
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.5.tgz",
-      "integrity": "sha512-qqKyjDXUaZwDuccpbMMKCCMBftvrbXzigtIsikAH/9ca+kaae8InP2MDf+Y/PdCSMuAsSpHS6q6M25irBBUh+Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.6.tgz",
+      "integrity": "sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "expect": "^27.0.2"
+        "@jest/environment": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "expect": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.5.tgz",
-      "integrity": "sha512-4uNg5+0eIfRafnpgu3jCZws3NNcFzhu5JdRd1mKQ4/53+vkIqwB6vfZ4gn5BdGqOaLtYhlOsPaL5ATkKzyBrJw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.6.tgz",
+      "integrity": "sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.0.2",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -994,10 +995,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.0.5",
-        "jest-resolve": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
+        "jest-haste-map": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1017,9 +1018,9 @@
       }
     },
     "node_modules/@jest/source-map": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.1.tgz",
-      "integrity": "sha512-yMgkF0f+6WJtDMdDYNavmqvbHtiSpwRN2U/W+6uztgfqgkq/PXdKPqjBTUF1RD/feth4rH5N3NW0T5+wIuln1A==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.6.tgz",
+      "integrity": "sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==",
       "dev": true,
       "dependencies": {
         "callsites": "^3.0.0",
@@ -1031,13 +1032,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.2.tgz",
-      "integrity": "sha512-gcdWwL3yP5VaIadzwQtbZyZMgpmes8ryBAJp70tuxghiA8qL4imJyZex+i+USQH2H4jeLVVszhwntgdQ97fccA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.6.tgz",
+      "integrity": "sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -1046,36 +1047,36 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.5.tgz",
-      "integrity": "sha512-opztnGs+cXzZ5txFG2+omBaV5ge/0yuJNKbhE3DREMiXE0YxBuzyEa6pNv3kk2JuucIlH2Xvgmn9kEEHSNt/SA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
+      "integrity": "sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.0.2",
+        "@jest/test-result": "^27.0.6",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-runtime": "^27.0.5"
+        "jest-haste-map": "^27.0.6",
+        "jest-runtime": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/transform": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.5.tgz",
-      "integrity": "sha512-lBD6OwKXSc6JJECBNk4mVxtSVuJSBsQrJ9WCBisfJs7EZuYq4K6vM9HmoB7hmPiLIDGeyaerw3feBV/bC4z8tg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.6.tgz",
+      "integrity": "sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-regex-util": "^27.0.1",
-        "jest-util": "^27.0.2",
+        "jest-haste-map": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-util": "^27.0.6",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -1087,9 +1088,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-      "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+      "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1340,9 +1341,9 @@
       "dev": true
     },
     "node_modules/@types/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-NVkb4p4YjI8E3O6+1m8I+8JlMpFZwfSbPGdaw0wXuyPRTEz0SLKwBUWNSO7Maoi8tQMPC8JLZNWkrcKPI7/sLA==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -1367,13 +1368,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.0.tgz",
-      "integrity": "sha512-KcF6p3zWhf1f8xO84tuBailV5cN92vhS+VT7UJsPzGBm9VnQqfI9AsiMUFUCYHTYPg1uCCo+HyiDnpDuvkAMfQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz",
+      "integrity": "sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.28.0",
-        "@typescript-eslint/scope-manager": "4.28.0",
+        "@typescript-eslint/experimental-utils": "4.28.1",
+        "@typescript-eslint/scope-manager": "4.28.1",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -1398,15 +1399,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.0.tgz",
-      "integrity": "sha512-9XD9s7mt3QWMk82GoyUpc/Ji03vz4T5AYlHF9DcoFNfJ/y3UAclRsfGiE2gLfXtyC+JRA3trR7cR296TEb1oiQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz",
+      "integrity": "sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.28.0",
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/typescript-estree": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/typescript-estree": "4.28.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1422,14 +1423,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.0.tgz",
-      "integrity": "sha512-7x4D22oPY8fDaOCvkuXtYYTQ6mTMmkivwEzS+7iml9F9VkHGbbZ3x4fHRwxAb5KeuSkLqfnYjs46tGx2Nour4A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.1.tgz",
+      "integrity": "sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.28.0",
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/typescript-estree": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/typescript-estree": "4.28.1",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1449,13 +1450,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz",
-      "integrity": "sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz",
+      "integrity": "sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0"
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1466,9 +1467,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.0.tgz",
-      "integrity": "sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
+      "integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1479,13 +1480,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz",
-      "integrity": "sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
+      "integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -1506,12 +1507,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz",
-      "integrity": "sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
+      "integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -1796,16 +1797,16 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.5.tgz",
-      "integrity": "sha512-bTMAbpCX7ldtfbca2llYLeSFsDM257aspyAOpsdrdSrBqoLkWCy4HPYTXtXWaSLgFPjrJGACL65rzzr4RFGadw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
+      "integrity": "sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.1",
+        "babel-preset-jest": "^27.0.6",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -1843,9 +1844,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.1.tgz",
-      "integrity": "sha512-sqBF0owAcCDBVEDtxqfYr2F36eSHdx7lAVGyYuOBRnKdD6gzcy0I0XrAYCZgOA3CRrLhmR+Uae9nogPzmAtOfQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
+      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -1881,12 +1882,12 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.1.tgz",
-      "integrity": "sha512-nIBIqCEpuiyhvjQs2mVNwTxQQa2xk70p9Dd/0obQGBf8FBzbnI8QhQKzLsWMN2i6q+5B0OcWDtrboBX5gmOLyA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
+      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "^27.0.1",
+        "babel-plugin-jest-hoist": "^27.0.6",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
@@ -2461,9 +2462,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
-      "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
       "dev": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -3494,17 +3495,17 @@
       "dev": true
     },
     "node_modules/expect": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.2.tgz",
-      "integrity": "sha512-YJFNJe2+P2DqH+ZrXy+ydRQYO87oxRUonZImpDodR1G7qo3NYd3pL+NQ9Keqpez3cehczYwZDBC3A7xk3n7M/w==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
+      "integrity": "sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.1",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-regex-util": "^27.0.1"
+        "jest-get-type": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-regex-util": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -4623,14 +4624,14 @@
       }
     },
     "node_modules/jest": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.5.tgz",
-      "integrity": "sha512-4NlVMS29gE+JOZvgmSAsz3eOjkSsHqjTajlIsah/4MVSmKvf3zFP/TvgcLoWe2UVHiE9KF741sReqhF0p4mqbQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
+      "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.0.5",
+        "@jest/core": "^27.0.6",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.0.5"
+        "jest-cli": "^27.0.6"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -4648,12 +4649,12 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.2.tgz",
-      "integrity": "sha512-eMeb1Pn7w7x3wue5/vF73LPCJ7DKQuC9wQUR5ebP9hDPpk5hzcT/3Hmz3Q5BOFpR3tgbmaWhJcMTVgC8Z1NuMw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
+      "integrity": "sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       },
@@ -4662,27 +4663,27 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.5.tgz",
-      "integrity": "sha512-p5rO90o1RTh8LPOG6l0Fc9qgp5YGv+8M5CFixhMh7gGHtGSobD1AxX9cjFZujILgY8t30QZ7WVvxlnuG31r8TA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.6.tgz",
+      "integrity": "sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.0.2",
+        "expect": "^27.0.6",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.2",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2",
+        "jest-each": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
@@ -4692,21 +4693,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.5.tgz",
-      "integrity": "sha512-kZqY020QFOFQKVE2knFHirTBElw3/Q0kUbDc3nMfy/x+RQ7zUY89SUuzpHHJoSX1kX7Lq569ncvjNqU3Td/FCA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.6.tgz",
+      "integrity": "sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/core": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "import-local": "^3.0.2",
-        "jest-config": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-config": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "prompts": "^2.0.1",
         "yargs": "^16.0.3"
       },
@@ -4726,32 +4727,32 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.5.tgz",
-      "integrity": "sha512-zCUIXag7QIXKEVN4kUKbDBDi9Q53dV5o3eNhGqe+5zAbt1vLs4VE3ceWaYrOub0L4Y7E9pGfM84TX/0ARcE+Qw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.6.tgz",
+      "integrity": "sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "babel-jest": "^27.0.5",
+        "@jest/test-sequencer": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "babel-jest": "^27.0.6",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.0.5",
-        "jest-environment-jsdom": "^27.0.5",
-        "jest-environment-node": "^27.0.5",
-        "jest-get-type": "^27.0.1",
-        "jest-jasmine2": "^27.0.5",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-runner": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-circus": "^27.0.6",
+        "jest-environment-jsdom": "^27.0.6",
+        "jest-environment-node": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "jest-jasmine2": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-runner": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.2"
+        "pretty-format": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -4766,24 +4767,24 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.2.tgz",
-      "integrity": "sha512-BFIdRb0LqfV1hBt8crQmw6gGQHVDhM87SpMIZ45FPYKReZYG5er1+5pIn2zKqvrJp6WNox0ylR8571Iwk2Dmgw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+      "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.0.1",
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "diff-sequences": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.1.tgz",
-      "integrity": "sha512-TA4+21s3oebURc7VgFV4r7ltdIJ5rtBH1E3Tbovcg7AV+oLfD5DcJ2V2vJ5zFA9sL5CFd/d2D6IpsAeSheEdrA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.6.tgz",
+      "integrity": "sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -4793,33 +4794,33 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.2.tgz",
-      "integrity": "sha512-OLMBZBZ6JkoXgUenDtseFRWA43wVl2BwmZYIWQws7eS7pqsIvePqj/jJmEnfq91ALk3LNphgwNK/PRFBYi7ITQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.6.tgz",
+      "integrity": "sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2"
+        "jest-get-type": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.5.tgz",
-      "integrity": "sha512-ToWhViIoTl5738oRaajTMgYhdQL73UWPoV4GqHGk2DPhs+olv8OLq5KoQW8Yf+HtRao52XLqPWvl46dPI88PdA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
+      "integrity": "sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2",
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6",
         "jsdom": "^16.6.0"
       },
       "engines": {
@@ -4827,47 +4828,47 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.5.tgz",
-      "integrity": "sha512-47qqScV/WMVz5OKF5TWpAeQ1neZKqM3ySwNveEnLyd+yaE/KT6lSMx/0SOx60+ZUcVxPiESYS+Kt2JS9y4PpkQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
+      "integrity": "sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2"
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+      "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
       "dev": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.5.tgz",
-      "integrity": "sha512-3LFryGSHxwPFHzKIs6W0BGA2xr6g1MvzSjR3h3D8K8Uqy4vbRm/grpGHzbPtIbOPLC6wFoViRrNEmd116QWSkw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
+      "integrity": "sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-regex-util": "^27.0.1",
-        "jest-serializer": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
+        "jest-regex-util": "^27.0.6",
+        "jest-serializer": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       },
@@ -4879,28 +4880,28 @@
       }
     },
     "node_modules/jest-jasmine2": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.5.tgz",
-      "integrity": "sha512-m3TojR19sFmTn79QoaGy1nOHBcLvtLso6Zh7u+gYxZWGcza4rRPVqwk1hciA5ZOWWZIJOukAcore8JRX992FaA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
+      "integrity": "sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==",
       "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.0.5",
-        "@jest/source-map": "^27.0.1",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.0.2",
+        "expect": "^27.0.6",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.2",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2",
+        "jest-each": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6",
         "throat": "^6.0.1"
       },
       "engines": {
@@ -4908,46 +4909,46 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.2.tgz",
-      "integrity": "sha512-TZA3DmCOfe8YZFIMD1GxFqXUkQnIoOGQyy4hFCA2mlHtnAaf+FeOMxi0fZmfB41ZL+QbFG6BVaZF5IeFIVy53Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
+      "integrity": "sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
-      "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
+      "integrity": "sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.0.2",
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "jest-diff": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.2.tgz",
-      "integrity": "sha512-rTqWUX42ec2LdMkoUPOzrEd1Tcm+R1KfLOmFK+OVNo4MnLsEaxO5zPDb2BbdSmthdM/IfXxOZU60P/WbWF8BTw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.6.tgz",
+      "integrity": "sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.2",
+        "pretty-format": "^27.0.6",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -4968,12 +4969,12 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.3.tgz",
-      "integrity": "sha512-O5FZn5XDzEp+Xg28mUz4ovVcdwBBPfAhW9+zJLO0Efn2qNbYcDaJvSlRiQ6BCZUCVOJjALicuJQI9mRFjv1o9Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.6.tgz",
+      "integrity": "sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/node": "*"
       },
       "engines": {
@@ -4998,27 +4999,27 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.1.tgz",
-      "integrity": "sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
+      "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
       "dev": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.5.tgz",
-      "integrity": "sha512-Md65pngRh8cRuWVdWznXBB5eDt391OJpdBaJMxfjfuXCvOhM3qQBtLMCMTykhuUKiBMmy5BhqCW7AVOKmPrW+Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.6.tgz",
+      "integrity": "sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       },
@@ -5027,45 +5028,45 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.5.tgz",
-      "integrity": "sha512-xUj2dPoEEd59P+nuih4XwNa4nJ/zRd/g4rMvjHrZPEBWeWRq/aJnnM6mug+B+Nx+ILXGtfWHzQvh7TqNV/WbuA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
+      "integrity": "sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
-        "jest-regex-util": "^27.0.1",
-        "jest-snapshot": "^27.0.5"
+        "@jest/types": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-snapshot": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.5.tgz",
-      "integrity": "sha512-HNhOtrhfKPArcECgBTcWOc+8OSL8GoFoa7RsHGnfZR1C1dFohxy9eLtpYBS+koybAHlJLZzNCx2Y/Ic3iEtJpQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.6.tgz",
+      "integrity": "sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.0.2",
-        "@jest/environment": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/environment": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-docblock": "^27.0.1",
-        "jest-environment-jsdom": "^27.0.5",
-        "jest-environment-node": "^27.0.5",
-        "jest-haste-map": "^27.0.5",
-        "jest-leak-detector": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-resolve": "^27.0.5",
-        "jest-runtime": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
+        "jest-docblock": "^27.0.6",
+        "jest-environment-jsdom": "^27.0.6",
+        "jest-environment-node": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-leak-detector": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       },
@@ -5074,19 +5075,19 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.5.tgz",
-      "integrity": "sha512-V/w/+VasowPESbmhXn5AsBGPfb35T7jZPGZybYTHxZdP7Gwaa+A0EXE6rx30DshHKA98lVCODbCO8KZpEW3hiQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
+      "integrity": "sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.0.2",
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/globals": "^27.0.5",
-        "@jest/source-map": "^27.0.1",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/globals": "^27.0.6",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -5094,14 +5095,14 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-message-util": "^27.0.2",
-        "jest-mock": "^27.0.3",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-haste-map": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-mock": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.0.3"
@@ -5120,9 +5121,9 @@
       }
     },
     "node_modules/jest-serializer": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.1.tgz",
-      "integrity": "sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.6.tgz",
+      "integrity": "sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -5133,9 +5134,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.5.tgz",
-      "integrity": "sha512-H1yFYdgnL1vXvDqMrnDStH6yHFdMEuzYQYc71SnC/IJnuuhW6J16w8GWG1P+qGd3Ag3sQHjbRr0TcwEo/vGS+g==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
+      "integrity": "sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.7.2",
@@ -5144,36 +5145,45 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.0.2",
+        "expect": "^27.0.6",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.0.2",
-        "jest-get-type": "^27.0.1",
-        "jest-haste-map": "^27.0.5",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-resolve": "^27.0.5",
-        "jest-util": "^27.0.2",
+        "jest-diff": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-util": "^27.0.6",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.0.2",
+        "pretty-format": "^27.0.6",
         "semver": "^7.3.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/jest-ts-webcompat-resolver": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz",
+      "integrity": "sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==",
+      "dev": true,
+      "peerDependencies": {
+        "jest-resolve": "*"
+      }
+    },
     "node_modules/jest-util": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.2.tgz",
-      "integrity": "sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
+      "integrity": "sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -5185,17 +5195,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.2.tgz",
-      "integrity": "sha512-UgBF6/oVu1ofd1XbaSotXKihi8nZhg0Prm8twQ9uCuAfo59vlxCXMPI/RKmrZEVgi3Nd9dS0I8A0wzWU48pOvg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.6.tgz",
+      "integrity": "sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.1",
+        "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.0.2"
+        "pretty-format": "^27.0.6"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -5214,17 +5224,17 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.2.tgz",
-      "integrity": "sha512-8nuf0PGuTxWj/Ytfw5fyvNn/R80iXY8QhIT0ofyImUvdnoaBdT6kob0GmhXR+wO+ALYVnh8bQxN4Tjfez0JgkA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.6.tgz",
+      "integrity": "sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.0.2",
+        "jest-util": "^27.0.6",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -5232,9 +5242,9 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-      "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+      "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -6174,12 +6184,12 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-      "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+      "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
@@ -7718,9 +7728,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8034,9 +8044,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -8654,9 +8664,9 @@
       }
     },
     "@foxglove/eslint-plugin": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@foxglove/eslint-plugin/-/eslint-plugin-0.11.1.tgz",
-      "integrity": "sha512-c3rGYgitP9ATCzz7xtOgcy+a/UkKFTURKf4zykx3P3Z91eeHPaXFRaTWeRJbxlNj+zlWVA7U5QJNW4h3yj5UzQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@foxglove/eslint-plugin/-/eslint-plugin-0.12.0.tgz",
+      "integrity": "sha512-pBVoH0eZHYCURTbSYLO0DKxBo/zBn5P/t3HurU6njgt8caQ2SIPCWYleXwA2Cbr4+RepUB6+l53JR3m9bfa/Fg==",
       "dev": true,
       "requires": {}
     },
@@ -8743,49 +8753,49 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.2.tgz",
-      "integrity": "sha512-/zYigssuHLImGeMAACkjI4VLAiiJznHgAl3xnFT19iWyct2LhrH3KXOjHRmxBGTkiPLZKKAJAgaPpiU9EZ9K+w==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.6.tgz",
+      "integrity": "sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.0.2",
-        "jest-util": "^27.0.2",
+        "jest-message-util": "^27.0.6",
+        "jest-util": "^27.0.6",
         "slash": "^3.0.0"
       }
     },
     "@jest/core": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.5.tgz",
-      "integrity": "sha512-g73//jF0VwsOIrWUC9Cqg03lU3QoAMFxVjsm6n6yNmwZcQPN/o8w+gLWODw5VfKNFZT38otXHWxc6b8eGDUpEA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.6.tgz",
+      "integrity": "sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/reporters": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/reporters": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.0.2",
-        "jest-config": "^27.0.5",
-        "jest-haste-map": "^27.0.5",
-        "jest-message-util": "^27.0.2",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-resolve-dependencies": "^27.0.5",
-        "jest-runner": "^27.0.5",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
-        "jest-watcher": "^27.0.2",
+        "jest-changed-files": "^27.0.6",
+        "jest-config": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-resolve-dependencies": "^27.0.6",
+        "jest-runner": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
+        "jest-watcher": "^27.0.6",
         "micromatch": "^4.0.4",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -8794,53 +8804,53 @@
       }
     },
     "@jest/environment": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.5.tgz",
-      "integrity": "sha512-IAkJPOT7bqn0GiX5LPio6/e1YpcmLbrd8O5EFYpAOZ6V+9xJDsXjdgN2vgv9WOKIs/uA1kf5WeD96HhlBYO+FA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.6.tgz",
+      "integrity": "sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
-        "jest-mock": "^27.0.3"
+        "jest-mock": "^27.0.6"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.5.tgz",
-      "integrity": "sha512-d6Tyf7iDoKqeUdwUKrOBV/GvEZRF67m7lpuWI0+SCD9D3aaejiOQZxAOxwH2EH/W18gnfYaBPLi0VeTGBHtQBg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
+      "integrity": "sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@sinonjs/fake-timers": "^7.0.2",
         "@types/node": "*",
-        "jest-message-util": "^27.0.2",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2"
+        "jest-message-util": "^27.0.6",
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6"
       }
     },
     "@jest/globals": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.5.tgz",
-      "integrity": "sha512-qqKyjDXUaZwDuccpbMMKCCMBftvrbXzigtIsikAH/9ca+kaae8InP2MDf+Y/PdCSMuAsSpHS6q6M25irBBUh+Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.6.tgz",
+      "integrity": "sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "expect": "^27.0.2"
+        "@jest/environment": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "expect": "^27.0.6"
       }
     },
     "@jest/reporters": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.5.tgz",
-      "integrity": "sha512-4uNg5+0eIfRafnpgu3jCZws3NNcFzhu5JdRd1mKQ4/53+vkIqwB6vfZ4gn5BdGqOaLtYhlOsPaL5ATkKzyBrJw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.6.tgz",
+      "integrity": "sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.0.2",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -8851,10 +8861,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.0.5",
-        "jest-resolve": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
+        "jest-haste-map": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -8863,9 +8873,9 @@
       }
     },
     "@jest/source-map": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.1.tgz",
-      "integrity": "sha512-yMgkF0f+6WJtDMdDYNavmqvbHtiSpwRN2U/W+6uztgfqgkq/PXdKPqjBTUF1RD/feth4rH5N3NW0T5+wIuln1A==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.6.tgz",
+      "integrity": "sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -8874,45 +8884,45 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.2.tgz",
-      "integrity": "sha512-gcdWwL3yP5VaIadzwQtbZyZMgpmes8ryBAJp70tuxghiA8qL4imJyZex+i+USQH2H4jeLVVszhwntgdQ97fccA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.6.tgz",
+      "integrity": "sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.5.tgz",
-      "integrity": "sha512-opztnGs+cXzZ5txFG2+omBaV5ge/0yuJNKbhE3DREMiXE0YxBuzyEa6pNv3kk2JuucIlH2Xvgmn9kEEHSNt/SA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
+      "integrity": "sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.2",
+        "@jest/test-result": "^27.0.6",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-runtime": "^27.0.5"
+        "jest-haste-map": "^27.0.6",
+        "jest-runtime": "^27.0.6"
       }
     },
     "@jest/transform": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.5.tgz",
-      "integrity": "sha512-lBD6OwKXSc6JJECBNk4mVxtSVuJSBsQrJ9WCBisfJs7EZuYq4K6vM9HmoB7hmPiLIDGeyaerw3feBV/bC4z8tg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.6.tgz",
+      "integrity": "sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-regex-util": "^27.0.1",
-        "jest-util": "^27.0.2",
+        "jest-haste-map": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-util": "^27.0.6",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -8921,9 +8931,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
-      "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+      "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -9146,9 +9156,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-NVkb4p4YjI8E3O6+1m8I+8JlMpFZwfSbPGdaw0wXuyPRTEz0SLKwBUWNSO7Maoi8tQMPC8JLZNWkrcKPI7/sLA==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -9173,13 +9183,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.0.tgz",
-      "integrity": "sha512-KcF6p3zWhf1f8xO84tuBailV5cN92vhS+VT7UJsPzGBm9VnQqfI9AsiMUFUCYHTYPg1uCCo+HyiDnpDuvkAMfQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz",
+      "integrity": "sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.28.0",
-        "@typescript-eslint/scope-manager": "4.28.0",
+        "@typescript-eslint/experimental-utils": "4.28.1",
+        "@typescript-eslint/scope-manager": "4.28.1",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -9188,55 +9198,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.0.tgz",
-      "integrity": "sha512-9XD9s7mt3QWMk82GoyUpc/Ji03vz4T5AYlHF9DcoFNfJ/y3UAclRsfGiE2gLfXtyC+JRA3trR7cR296TEb1oiQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz",
+      "integrity": "sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.28.0",
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/typescript-estree": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/typescript-estree": "4.28.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.0.tgz",
-      "integrity": "sha512-7x4D22oPY8fDaOCvkuXtYYTQ6mTMmkivwEzS+7iml9F9VkHGbbZ3x4fHRwxAb5KeuSkLqfnYjs46tGx2Nour4A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.1.tgz",
+      "integrity": "sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.28.0",
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/typescript-estree": "4.28.0",
+        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/typescript-estree": "4.28.1",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz",
-      "integrity": "sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz",
+      "integrity": "sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0"
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.0.tgz",
-      "integrity": "sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
+      "integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz",
-      "integrity": "sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
+      "integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
-        "@typescript-eslint/visitor-keys": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -9245,12 +9255,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz",
-      "integrity": "sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
+      "integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.0",
+        "@typescript-eslint/types": "4.28.1",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -9446,16 +9456,16 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.5.tgz",
-      "integrity": "sha512-bTMAbpCX7ldtfbca2llYLeSFsDM257aspyAOpsdrdSrBqoLkWCy4HPYTXtXWaSLgFPjrJGACL65rzzr4RFGadw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
+      "integrity": "sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.1",
+        "babel-preset-jest": "^27.0.6",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -9484,9 +9494,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.1.tgz",
-      "integrity": "sha512-sqBF0owAcCDBVEDtxqfYr2F36eSHdx7lAVGyYuOBRnKdD6gzcy0I0XrAYCZgOA3CRrLhmR+Uae9nogPzmAtOfQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
+      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -9516,12 +9526,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.1.tgz",
-      "integrity": "sha512-nIBIqCEpuiyhvjQs2mVNwTxQQa2xk70p9Dd/0obQGBf8FBzbnI8QhQKzLsWMN2i6q+5B0OcWDtrboBX5gmOLyA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
+      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.0.1",
+        "babel-plugin-jest-hoist": "^27.0.6",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -9978,9 +9988,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
-      "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
       "dev": true
     },
     "dir-glob": {
@@ -10778,17 +10788,17 @@
       }
     },
     "expect": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.2.tgz",
-      "integrity": "sha512-YJFNJe2+P2DqH+ZrXy+ydRQYO87oxRUonZImpDodR1G7qo3NYd3pL+NQ9Keqpez3cehczYwZDBC3A7xk3n7M/w==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
+      "integrity": "sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.1",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-regex-util": "^27.0.1"
+        "jest-get-type": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11620,254 +11630,254 @@
       }
     },
     "jest": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.5.tgz",
-      "integrity": "sha512-4NlVMS29gE+JOZvgmSAsz3eOjkSsHqjTajlIsah/4MVSmKvf3zFP/TvgcLoWe2UVHiE9KF741sReqhF0p4mqbQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
+      "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.5",
+        "@jest/core": "^27.0.6",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.0.5"
+        "jest-cli": "^27.0.6"
       }
     },
     "jest-changed-files": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.2.tgz",
-      "integrity": "sha512-eMeb1Pn7w7x3wue5/vF73LPCJ7DKQuC9wQUR5ebP9hDPpk5hzcT/3Hmz3Q5BOFpR3tgbmaWhJcMTVgC8Z1NuMw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
+      "integrity": "sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       }
     },
     "jest-circus": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.5.tgz",
-      "integrity": "sha512-p5rO90o1RTh8LPOG6l0Fc9qgp5YGv+8M5CFixhMh7gGHtGSobD1AxX9cjFZujILgY8t30QZ7WVvxlnuG31r8TA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.6.tgz",
+      "integrity": "sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.0.2",
+        "expect": "^27.0.6",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.2",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2",
+        "jest-each": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       }
     },
     "jest-cli": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.5.tgz",
-      "integrity": "sha512-kZqY020QFOFQKVE2knFHirTBElw3/Q0kUbDc3nMfy/x+RQ7zUY89SUuzpHHJoSX1kX7Lq569ncvjNqU3Td/FCA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.6.tgz",
+      "integrity": "sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/core": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "import-local": "^3.0.2",
-        "jest-config": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-config": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "prompts": "^2.0.1",
         "yargs": "^16.0.3"
       }
     },
     "jest-config": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.5.tgz",
-      "integrity": "sha512-zCUIXag7QIXKEVN4kUKbDBDi9Q53dV5o3eNhGqe+5zAbt1vLs4VE3ceWaYrOub0L4Y7E9pGfM84TX/0ARcE+Qw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.6.tgz",
+      "integrity": "sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.0.5",
-        "@jest/types": "^27.0.2",
-        "babel-jest": "^27.0.5",
+        "@jest/test-sequencer": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "babel-jest": "^27.0.6",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.0.5",
-        "jest-environment-jsdom": "^27.0.5",
-        "jest-environment-node": "^27.0.5",
-        "jest-get-type": "^27.0.1",
-        "jest-jasmine2": "^27.0.5",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-runner": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-circus": "^27.0.6",
+        "jest-environment-jsdom": "^27.0.6",
+        "jest-environment-node": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "jest-jasmine2": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-runner": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.2"
+        "pretty-format": "^27.0.6"
       }
     },
     "jest-diff": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.2.tgz",
-      "integrity": "sha512-BFIdRb0LqfV1hBt8crQmw6gGQHVDhM87SpMIZ45FPYKReZYG5er1+5pIn2zKqvrJp6WNox0ylR8571Iwk2Dmgw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+      "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.0.1",
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "diff-sequences": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
       }
     },
     "jest-docblock": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.1.tgz",
-      "integrity": "sha512-TA4+21s3oebURc7VgFV4r7ltdIJ5rtBH1E3Tbovcg7AV+oLfD5DcJ2V2vJ5zFA9sL5CFd/d2D6IpsAeSheEdrA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.6.tgz",
+      "integrity": "sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.2.tgz",
-      "integrity": "sha512-OLMBZBZ6JkoXgUenDtseFRWA43wVl2BwmZYIWQws7eS7pqsIvePqj/jJmEnfq91ALk3LNphgwNK/PRFBYi7ITQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.6.tgz",
+      "integrity": "sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2"
+        "jest-get-type": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6"
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.5.tgz",
-      "integrity": "sha512-ToWhViIoTl5738oRaajTMgYhdQL73UWPoV4GqHGk2DPhs+olv8OLq5KoQW8Yf+HtRao52XLqPWvl46dPI88PdA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
+      "integrity": "sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2",
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6",
         "jsdom": "^16.6.0"
       }
     },
     "jest-environment-node": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.5.tgz",
-      "integrity": "sha512-47qqScV/WMVz5OKF5TWpAeQ1neZKqM3ySwNveEnLyd+yaE/KT6lSMx/0SOx60+ZUcVxPiESYS+Kt2JS9y4PpkQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
+      "integrity": "sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
-        "jest-mock": "^27.0.3",
-        "jest-util": "^27.0.2"
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6"
       }
     },
     "jest-get-type": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
-      "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+      "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.5.tgz",
-      "integrity": "sha512-3LFryGSHxwPFHzKIs6W0BGA2xr6g1MvzSjR3h3D8K8Uqy4vbRm/grpGHzbPtIbOPLC6wFoViRrNEmd116QWSkw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
+      "integrity": "sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
-        "jest-regex-util": "^27.0.1",
-        "jest-serializer": "^27.0.1",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
+        "jest-regex-util": "^27.0.6",
+        "jest-serializer": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.5.tgz",
-      "integrity": "sha512-m3TojR19sFmTn79QoaGy1nOHBcLvtLso6Zh7u+gYxZWGcza4rRPVqwk1hciA5ZOWWZIJOukAcore8JRX992FaA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
+      "integrity": "sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.0.5",
-        "@jest/source-map": "^27.0.1",
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/environment": "^27.0.6",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.0.2",
+        "expect": "^27.0.6",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.2",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-runtime": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "pretty-format": "^27.0.2",
+        "jest-each": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6",
         "throat": "^6.0.1"
       }
     },
     "jest-leak-detector": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.2.tgz",
-      "integrity": "sha512-TZA3DmCOfe8YZFIMD1GxFqXUkQnIoOGQyy4hFCA2mlHtnAaf+FeOMxi0fZmfB41ZL+QbFG6BVaZF5IeFIVy53Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
+      "integrity": "sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
-      "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
+      "integrity": "sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.0.2",
-        "jest-get-type": "^27.0.1",
-        "pretty-format": "^27.0.2"
+        "jest-diff": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
       }
     },
     "jest-message-util": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.2.tgz",
-      "integrity": "sha512-rTqWUX42ec2LdMkoUPOzrEd1Tcm+R1KfLOmFK+OVNo4MnLsEaxO5zPDb2BbdSmthdM/IfXxOZU60P/WbWF8BTw==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.6.tgz",
+      "integrity": "sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.2",
+        "pretty-format": "^27.0.6",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -11884,12 +11894,12 @@
       }
     },
     "jest-mock": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.3.tgz",
-      "integrity": "sha512-O5FZn5XDzEp+Xg28mUz4ovVcdwBBPfAhW9+zJLO0Efn2qNbYcDaJvSlRiQ6BCZUCVOJjALicuJQI9mRFjv1o9Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.6.tgz",
+      "integrity": "sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/node": "*"
       }
     },
@@ -11901,83 +11911,83 @@
       "requires": {}
     },
     "jest-regex-util": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.1.tgz",
-      "integrity": "sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
+      "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.5.tgz",
-      "integrity": "sha512-Md65pngRh8cRuWVdWznXBB5eDt391OJpdBaJMxfjfuXCvOhM3qQBtLMCMTykhuUKiBMmy5BhqCW7AVOKmPrW+Q==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.6.tgz",
+      "integrity": "sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.5.tgz",
-      "integrity": "sha512-xUj2dPoEEd59P+nuih4XwNa4nJ/zRd/g4rMvjHrZPEBWeWRq/aJnnM6mug+B+Nx+ILXGtfWHzQvh7TqNV/WbuA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
+      "integrity": "sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
-        "jest-regex-util": "^27.0.1",
-        "jest-snapshot": "^27.0.5"
+        "@jest/types": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-snapshot": "^27.0.6"
       }
     },
     "jest-runner": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.5.tgz",
-      "integrity": "sha512-HNhOtrhfKPArcECgBTcWOc+8OSL8GoFoa7RsHGnfZR1C1dFohxy9eLtpYBS+koybAHlJLZzNCx2Y/Ic3iEtJpQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.6.tgz",
+      "integrity": "sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/environment": "^27.0.5",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/environment": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-docblock": "^27.0.1",
-        "jest-environment-jsdom": "^27.0.5",
-        "jest-environment-node": "^27.0.5",
-        "jest-haste-map": "^27.0.5",
-        "jest-leak-detector": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-resolve": "^27.0.5",
-        "jest-runtime": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-worker": "^27.0.2",
+        "jest-docblock": "^27.0.6",
+        "jest-environment-jsdom": "^27.0.6",
+        "jest-environment-node": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-leak-detector": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       }
     },
     "jest-runtime": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.5.tgz",
-      "integrity": "sha512-V/w/+VasowPESbmhXn5AsBGPfb35T7jZPGZybYTHxZdP7Gwaa+A0EXE6rx30DshHKA98lVCODbCO8KZpEW3hiQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
+      "integrity": "sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.2",
-        "@jest/environment": "^27.0.5",
-        "@jest/fake-timers": "^27.0.5",
-        "@jest/globals": "^27.0.5",
-        "@jest/source-map": "^27.0.1",
-        "@jest/test-result": "^27.0.2",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/console": "^27.0.6",
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/globals": "^27.0.6",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -11985,14 +11995,14 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.5",
-        "jest-message-util": "^27.0.2",
-        "jest-mock": "^27.0.3",
-        "jest-regex-util": "^27.0.1",
-        "jest-resolve": "^27.0.5",
-        "jest-snapshot": "^27.0.5",
-        "jest-util": "^27.0.2",
-        "jest-validate": "^27.0.2",
+        "jest-haste-map": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-mock": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^16.0.3"
@@ -12007,9 +12017,9 @@
       }
     },
     "jest-serializer": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.1.tgz",
-      "integrity": "sha512-svy//5IH6bfQvAbkAEg1s7xhhgHTtXu0li0I2fdKHDsLP2P2MOiscPQIENQep8oU2g2B3jqLyxKKzotZOz4CwQ==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.6.tgz",
+      "integrity": "sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -12017,9 +12027,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.0.5",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.5.tgz",
-      "integrity": "sha512-H1yFYdgnL1vXvDqMrnDStH6yHFdMEuzYQYc71SnC/IJnuuhW6J16w8GWG1P+qGd3Ag3sQHjbRr0TcwEo/vGS+g==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
+      "integrity": "sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -12028,33 +12038,40 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.0.5",
-        "@jest/types": "^27.0.2",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.0.2",
+        "expect": "^27.0.6",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.0.2",
-        "jest-get-type": "^27.0.1",
-        "jest-haste-map": "^27.0.5",
-        "jest-matcher-utils": "^27.0.2",
-        "jest-message-util": "^27.0.2",
-        "jest-resolve": "^27.0.5",
-        "jest-util": "^27.0.2",
+        "jest-diff": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-util": "^27.0.6",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.0.2",
+        "pretty-format": "^27.0.6",
         "semver": "^7.3.2"
       }
     },
+    "jest-ts-webcompat-resolver": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz",
+      "integrity": "sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==",
+      "dev": true,
+      "requires": {}
+    },
     "jest-util": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.2.tgz",
-      "integrity": "sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
+      "integrity": "sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -12063,17 +12080,17 @@
       }
     },
     "jest-validate": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.2.tgz",
-      "integrity": "sha512-UgBF6/oVu1ofd1XbaSotXKihi8nZhg0Prm8twQ9uCuAfo59vlxCXMPI/RKmrZEVgi3Nd9dS0I8A0wzWU48pOvg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.6.tgz",
+      "integrity": "sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.1",
+        "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.0.2"
+        "pretty-format": "^27.0.6"
       },
       "dependencies": {
         "camelcase": {
@@ -12085,24 +12102,24 @@
       }
     },
     "jest-watcher": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.2.tgz",
-      "integrity": "sha512-8nuf0PGuTxWj/Ytfw5fyvNn/R80iXY8QhIT0ofyImUvdnoaBdT6kob0GmhXR+wO+ALYVnh8bQxN4Tjfez0JgkA==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.6.tgz",
+      "integrity": "sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.2",
-        "@jest/types": "^27.0.2",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.0.2",
+        "jest-util": "^27.0.6",
         "string-length": "^4.0.1"
       }
     },
     "jest-worker": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-      "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+      "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -12818,12 +12835,12 @@
       }
     },
     "pretty-format": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
-      "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+      "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.2",
+        "@jest/types": "^27.0.6",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
@@ -14023,9 +14040,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -14279,9 +14296,9 @@
       }
     },
     "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -25,19 +25,20 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@foxglove/eslint-plugin": "0.11.1",
+    "@foxglove/eslint-plugin": "0.12.0",
     "@foxglove/tsconfig": "1.0.0",
     "@types/jest": "26.0.23",
-    "@typescript-eslint/eslint-plugin": "4.28.0",
-    "@typescript-eslint/parser": "4.28.0",
+    "@typescript-eslint/eslint-plugin": "4.28.1",
+    "@typescript-eslint/parser": "4.28.1",
     "esbuild-jest": "0.5.0",
     "eslint": "7.29.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.23.4",
     "eslint-plugin-jest": "24.3.6",
     "eslint-plugin-prettier": "3.4.0",
-    "jest": "27.0.5",
+    "jest": "27.0.6",
+    "jest-ts-webcompat-resolver": "^1.0.0",
     "prettier": "2.3.2",
-    "typescript": "4.3.4"
+    "typescript": "4.3.5"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import foo from "./index";
+import foo from "./index.js";
 
 describe("foo", () => {
   it("returns a value", () => {


### PR DESCRIPTION
Per https://github.com/foxglove/xmlrpc/pull/2: use explicit `.js` file extensions in imports, and add `jest-ts-webcompat-resolver` to help jest understand what's going on.