### PR TITLE
Update build to produce cjs and esm variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,18 @@
     "email": "contact@foxglove.dev",
     "url": "https://foxglove.dev/"
   },
-  "main": "dist/index.js",
+  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "prepack": "tsc -b",
-    "clean": "tsc -b --clean",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:esm": "tsc -b tsconfig.json",
+    "build:cjs": "tsc -b tsconfig.cjs.json",
+    "prepack": "npm run build",
+    "clean": "tsc -b tsconfig.cjs.json --clean && tsc -b tsconfig.json --clean",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import foo from "./index";
+import { foo } from "./index";
 
 describe("foo", () => {
   it("returns a value", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export default function foo(): number {
+export function foo(): number {
   return 42;
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+// -*- jsonc -*-
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["./src/**/*"],
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist",
-    "module": "commonjs"
+    "outDir": "./dist/esm"
   }
 }


### PR DESCRIPTION
I've tested this by running `npm pack` and using the resulting package in another project. I was able to run jest (which used the cjs dist files) and also run webpack (which used the esm dist files).

Using `ts-node` also worked in the other project if I pointed ts-node at a tsconfig.json which specified `module: commonjs` since we've determined that CLI tools work best when getting cjs source files.