### PR TITLE
Remove jest-ts-webcompat-resolver

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
   transform: {
     "\\.ts$": "esbuild-jest",
   },
-  resolver: "jest-ts-webcompat-resolver",
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-jest": "24.4.0",
     "eslint-plugin-prettier": "3.4.0",
     "jest": "27.0.6",
-    "jest-ts-webcompat-resolver": "1.0.0",
     "prettier": "2.3.2",
     "rimraf": "3.0.2",
     "typescript": "4.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,11 +2950,6 @@ jest-snapshot@^27.0.6:
     pretty-format "^27.0.6"
     semver "^7.3.2"
 
-jest-ts-webcompat-resolver@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz#a554eb77446e1a8d2aabb810d6302bffaa00095c"
-  integrity sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==
-
 jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"


### PR DESCRIPTION
This was only needed for an old approach to ESM
