### PR TITLE
Run CI on PR events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: CI
 
 on:
-  - push
+  push:
+    branches: main
+    tags: v*
+  pull_request:
+    branches: "*"
 
 jobs:
   all:


### PR DESCRIPTION
Running CI on the Github `push` event only works for contributors who can push branches to the source repo. It does not trigger when someone makes a PR from a fork.

Instead, use the `pull_request` event which triggers when anyone submits a PR (from either the source repo or a fork).