### PR TITLE
Add tslib dependency, fix vscode eslint config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "eslint.options": {
-    "reportUnusedDisableDirectives": true
+    "reportUnusedDisableDirectives": "error"
   },
   "files.eol": "\n",
   "files.insertFinalNewline": true,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2"
+  },
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.13.0",
     "@foxglove/tsconfig": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,6 +3596,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"


### PR DESCRIPTION
**Public-Facing Changes**
- Add missing `tslib` dependency
- Fix VS Code ESLint config

**Description**
Fixes #153
Fixes #149 
Fixes FG-955
Fixes FG-956